### PR TITLE
TRITON-2502: should pass all linter checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,15 @@ linters:
       - linters:
           - unparam
         text: always receives
+      - linters:
+        - staticcheck
+        text: 'SA1019: stateConf.WaitForState is deprecated: Please use WaitForStateContext to ensure proper plugin shutdown'
+      - linters:
+        - staticcheck
+        text: 'SA1019: retry.Retry is deprecated: Please use RetryContext to ensure proper plugin shutdown'
+      - linters:
+        - staticcheck
+        text: 'SA1019: schema.ImportStatePassthrough is deprecated: Please use the context aware ImportStatePassthroughContext instead '
   settings:
     errcheck:
       exclude-functions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - misspell
     - nilerr
     - predeclared
-    #- staticcheck
+    - staticcheck
     - unconvert
     - unparam
     - unused

--- a/triton/client.go
+++ b/triton/client.go
@@ -23,7 +23,7 @@ type Client struct {
 func (c Client) Account() (*account.AccountClient, error) {
 	accountClient, err := account.NewClient(c.config)
 	if err != nil {
-		return nil, fmt.Errorf("Error Creating Triton Account Client: %s", err)
+		return nil, fmt.Errorf("error creating triton account client: %s", err)
 	}
 
 	if c.insecureSkipTLSVerify {
@@ -35,7 +35,7 @@ func (c Client) Account() (*account.AccountClient, error) {
 func (c Client) Compute() (*compute.ComputeClient, error) {
 	computeClient, err := compute.NewClient(c.config)
 	if err != nil {
-		return nil, fmt.Errorf("Error Creating Triton Compute Client: %s", err)
+		return nil, fmt.Errorf("error creating triton compute client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		computeClient.Client.InsecureSkipTLSVerify()
@@ -46,7 +46,7 @@ func (c Client) Compute() (*compute.ComputeClient, error) {
 func (c Client) Identity() (*identity.IdentityClient, error) {
 	identityClient, err := identity.NewClient(c.config)
 	if err != nil {
-		return nil, fmt.Errorf("Error Creating Triton Identity Client: %s", err)
+		return nil, fmt.Errorf("error creating triton identity client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		identityClient.Client.InsecureSkipTLSVerify()
@@ -57,7 +57,7 @@ func (c Client) Identity() (*identity.IdentityClient, error) {
 func (c Client) Network() (*network.NetworkClient, error) {
 	networkClient, err := network.NewClient(c.config)
 	if err != nil {
-		return nil, fmt.Errorf("Error Creating Triton Network Client: %s", err)
+		return nil, fmt.Errorf("error creating triton network client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		networkClient.Client.InsecureSkipTLSVerify()
@@ -68,7 +68,7 @@ func (c Client) Network() (*network.NetworkClient, error) {
 func (c Client) Services() (*services.ServiceGroupClient, error) {
 	servicesClient, err := services.NewClient(c.config)
 	if err != nil {
-		return nil, fmt.Errorf("Error Creating Triton Services Client: %s", err)
+		return nil, fmt.Errorf("error creating triton services client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		servicesClient.Client.InsecureSkipTLSVerify()

--- a/triton/client.go
+++ b/triton/client.go
@@ -1,9 +1,8 @@
 package triton
 
 import (
+	"fmt"
 	"sync"
-
-	"github.com/hashicorp/errwrap"
 
 	triton "github.com/TritonDataCenter/triton-go"
 	"github.com/TritonDataCenter/triton-go/account"
@@ -24,7 +23,7 @@ type Client struct {
 func (c Client) Account() (*account.AccountClient, error) {
 	accountClient, err := account.NewClient(c.config)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error Creating Triton Account Client: {{err}}", err)
+		return nil, fmt.Errorf("Error Creating Triton Account Client: %s", err)
 	}
 
 	if c.insecureSkipTLSVerify {
@@ -36,7 +35,7 @@ func (c Client) Account() (*account.AccountClient, error) {
 func (c Client) Compute() (*compute.ComputeClient, error) {
 	computeClient, err := compute.NewClient(c.config)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error Creating Triton Compute Client: {{err}}", err)
+		return nil, fmt.Errorf("Error Creating Triton Compute Client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		computeClient.Client.InsecureSkipTLSVerify()
@@ -47,7 +46,7 @@ func (c Client) Compute() (*compute.ComputeClient, error) {
 func (c Client) Identity() (*identity.IdentityClient, error) {
 	identityClient, err := identity.NewClient(c.config)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error Creating Triton Identity Client: {{err}}", err)
+		return nil, fmt.Errorf("Error Creating Triton Identity Client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		identityClient.Client.InsecureSkipTLSVerify()
@@ -58,7 +57,7 @@ func (c Client) Identity() (*identity.IdentityClient, error) {
 func (c Client) Network() (*network.NetworkClient, error) {
 	networkClient, err := network.NewClient(c.config)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error Creating Triton Network Client: {{err}}", err)
+		return nil, fmt.Errorf("Error Creating Triton Network Client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		networkClient.Client.InsecureSkipTLSVerify()
@@ -69,7 +68,7 @@ func (c Client) Network() (*network.NetworkClient, error) {
 func (c Client) Services() (*services.ServiceGroupClient, error) {
 	servicesClient, err := services.NewClient(c.config)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error Creating Triton Services Client: {{err}}", err)
+		return nil, fmt.Errorf("Error Creating Triton Services Client: %s", err)
 	}
 	if c.insecureSkipTLSVerify {
 		servicesClient.Client.InsecureSkipTLSVerify()

--- a/triton/data_source_image.go
+++ b/triton/data_source_image.go
@@ -114,8 +114,8 @@ func dataSourceImageRead(d *schema.ResourceData, meta interface{}) error {
 
 	var image *compute.Image
 	if len(images) == 0 {
-		return fmt.Errorf("Your query returned no results. Please change " +
-			"your search criteria and try again.")
+		return fmt.Errorf("your query returned no results, please change " +
+			"your search criteria and try again")
 	}
 
 	if len(images) > 1 {
@@ -124,8 +124,8 @@ func dataSourceImageRead(d *schema.ResourceData, meta interface{}) error {
 		if recent {
 			image = mostRecentImages(images)
 		} else {
-			return fmt.Errorf("Your query returned more than one result. " +
-				"Please try a more specific search criteria.")
+			return fmt.Errorf("your query returned more than one result, " +
+				"please try a more specific search criteria")
 		}
 	} else {
 		image = images[0]

--- a/triton/data_source_image_test.go
+++ b/triton/data_source_image_test.go
@@ -16,7 +16,7 @@ func TestAccTritonImage_multipleResults(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTritonImage_multipleResults,
-				ExpectError: regexp.MustCompile(`Your query returned more than one result`),
+				ExpectError: regexp.MustCompile(`your query returned more than one result`),
 			},
 		},
 	})
@@ -30,7 +30,7 @@ func TestAccTritonImage_noResults(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTritonImage_noResults,
-				ExpectError: regexp.MustCompile(`Your query returned no results`),
+				ExpectError: regexp.MustCompile(`your query returned no results`),
 			},
 		},
 	})

--- a/triton/data_source_package.go
+++ b/triton/data_source_package.go
@@ -130,7 +130,7 @@ func dataSourcePackageRead(d *schema.ResourceData, meta interface{}) error {
 	if filterSet, found := d.Get("filter").(*schema.Set); found {
 		filterRaw := filterSet.List()[0]
 		if filterRaw == nil {
-			return fmt.Errorf("Please set filters on your package data source.")
+			return fmt.Errorf("please set filters on your package data source")
 		}
 		filters = filterRaw.(map[string]interface{})
 	}
@@ -164,8 +164,8 @@ func dataSourcePackageRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if len(packages) == 0 {
-		return fmt.Errorf("Your query returned no results. Please change " +
-			"your filter criteria and try again.")
+		return fmt.Errorf("your query returned no results, please change " +
+			"your filter criteria and try again")
 	}
 
 	iname, hasName := filters["name"]
@@ -193,8 +193,8 @@ func dataSourcePackageRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		return fmt.Errorf(
-			"Your query returned more than one result (%v).\nPlease change "+
-				"your filter criteria and try again.", strings.Join(names, ", "))
+			"your query returned more than one result (%v),\nplease change "+
+				"your filter criteria and try again", strings.Join(names, ", "))
 	}
 
 	d.SetId(pkg.ID)

--- a/triton/data_source_volume.go
+++ b/triton/data_source_volume.go
@@ -84,14 +84,14 @@ func dataSourceVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if len(volumes) == 0 {
-		return fmt.Errorf("Your query returned no results. Please change " +
-			"your search criteria and try again.")
+		return fmt.Errorf("your query returned no results, please change " +
+			"your search criteria and try again")
 	}
 
 	if len(volumes) > 1 {
 		log.Printf("[DEBUG] triton_volume - %d results found", len(volumes))
-		return fmt.Errorf("Your query returned more than one result. " +
-			"Please try a more specific search criteria.")
+		return fmt.Errorf("your query returned more than one result, " +
+			"please try a more specific search criteria")
 	}
 
 	var volume *compute.Volume = volumes[0]

--- a/triton/data_source_volume.go
+++ b/triton/data_source_volume.go
@@ -94,7 +94,7 @@ func dataSourceVolumeRead(d *schema.ResourceData, meta interface{}) error {
 			"please try a more specific search criteria")
 	}
 
-	var volume *compute.Volume = volumes[0]
+	var volume = volumes[0]
 
 	return tritonVolumeToTerraformVolume(d, volume)
 }

--- a/triton/data_source_volume_test.go
+++ b/triton/data_source_volume_test.go
@@ -57,7 +57,7 @@ func TestAccTritonDataVolume_noResults(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`Your query returned no results`),
+				ExpectError: regexp.MustCompile(`your query returned no results`),
 			},
 		},
 	})

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -14,7 +14,6 @@ import (
 	triton "github.com/TritonDataCenter/triton-go"
 	"github.com/TritonDataCenter/triton-go/authentication"
 	"github.com/TritonDataCenter/triton-go/errors"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -129,7 +128,7 @@ func (c Config) newClient() (*Client, error) {
 			Username:    c.Username,
 		})
 		if err != nil {
-			return nil, errwrap.Wrapf("Error Creating SSH Agent Signer: {{err}}", err)
+			return nil, fmt.Errorf("Error Creating SSH Agent Signer: %s", err)
 		}
 	} else {
 		var keyBytes []byte
@@ -162,7 +161,7 @@ func (c Config) newClient() (*Client, error) {
 			Username:           c.Username,
 		})
 		if err != nil {
-			return nil, errwrap.Wrapf("Error Creating SSH Private Key Signer: {{err}}", err)
+			return nil, fmt.Errorf("Error Creating SSH Private Key Signer: %s", err)
 		}
 	}
 

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -4,7 +4,6 @@ import (
 	"encoding/pem"
 	stderrors "errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"time"
@@ -133,7 +132,7 @@ func (c Config) newClient() (*Client, error) {
 	} else {
 		var keyBytes []byte
 		if _, err = os.Stat(c.KeyMaterial); err == nil {
-			keyBytes, err = ioutil.ReadFile(c.KeyMaterial)
+			keyBytes, err = os.ReadFile(c.KeyMaterial)
 			if err != nil {
 				return nil, fmt.Errorf("Error reading key material from %s: %s",
 					c.KeyMaterial, err)

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -104,13 +104,13 @@ func (c Config) validate() error {
 	var err *multierror.Error
 
 	if c.URL == "" {
-		err = multierror.Append(err, stderrors.New("URL must be configured for the Triton provider"))
+		err = multierror.Append(err, stderrors.New("url must be configured for the triton provider"))
 	}
 	if c.KeyID == "" {
-		err = multierror.Append(err, stderrors.New("Key ID must be configured for the Triton provider"))
+		err = multierror.Append(err, stderrors.New("key id must be configured for the triton provider"))
 	}
 	if c.Account == "" {
-		err = multierror.Append(err, stderrors.New("Account must be configured for the Triton provider"))
+		err = multierror.Append(err, stderrors.New("account must be configured for the triton provider"))
 	}
 
 	return err.ErrorOrNil()
@@ -127,26 +127,26 @@ func (c Config) newClient() (*Client, error) {
 			Username:    c.Username,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Error Creating SSH Agent Signer: %s", err)
+			return nil, fmt.Errorf("error creating ssh agent signer: %s", err)
 		}
 	} else {
 		var keyBytes []byte
 		if _, err = os.Stat(c.KeyMaterial); err == nil {
 			keyBytes, err = os.ReadFile(c.KeyMaterial)
 			if err != nil {
-				return nil, fmt.Errorf("Error reading key material from %s: %s",
+				return nil, fmt.Errorf("error reading key material from %s: %s",
 					c.KeyMaterial, err)
 			}
 			block, _ := pem.Decode(keyBytes)
 			if block == nil {
 				return nil, fmt.Errorf(
-					"Failed to read key material '%s': no key found", c.KeyMaterial)
+					"failed to read key material '%s': no key found", c.KeyMaterial)
 			}
 
 			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
 				return nil, fmt.Errorf(
-					"Failed to read key '%s': password protected keys are\n"+
-						"not currently supported. Please decrypt the key prior to use.", c.KeyMaterial)
+					"failed to read key '%s': password protected keys are\n"+
+						"not currently supported, please decrypt the key prior to use", c.KeyMaterial)
 			}
 
 		} else {
@@ -160,7 +160,7 @@ func (c Config) newClient() (*Client, error) {
 			Username:           c.Username,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Error Creating SSH Private Key Signer: %s", err)
+			return nil, fmt.Errorf("error creating ssh private key signer: %s", err)
 		}
 	}
 

--- a/triton/resource_fabric.go
+++ b/triton/resource_fabric.go
@@ -137,7 +137,7 @@ func resourceFabricCreate(d *schema.ResourceData, meta interface{}) error {
 	for cidr, v := range d.Get("routes").(map[string]interface{}) {
 		ip, ok := v.(string)
 		if !ok {
-			return fmt.Errorf(`Cannot use "%v" as an IP address`, v)
+			return fmt.Errorf(`cannot use "%v" as an IP address`, v)
 		}
 		routes[cidr] = ip
 	}

--- a/triton/resource_fabric_migrate.go
+++ b/triton/resource_fabric_migrate.go
@@ -14,7 +14,7 @@ func resourceFabricMigrateState(
 		log.Println("[INFO] Found Fabric State v0; migrating to v1")
 		return migrateFabricStateV0toV1(is)
 	default:
-		return is, fmt.Errorf("Unexpected schema version: %d", v)
+		return is, fmt.Errorf("unexpected schema version: %d", v)
 	}
 }
 

--- a/triton/resource_fabric_test.go
+++ b/triton/resource_fabric_test.go
@@ -97,7 +97,7 @@ func testCheckTritonFabricDestroy(s *terraform.State) error {
 			NetworkID:    rs.Primary.ID,
 		}))
 		if err != nil {
-			return nil //nolint:nilerr
+			return err
 		}
 
 		if exists {

--- a/triton/resource_firewall_rule.go
+++ b/triton/resource_firewall_rule.go
@@ -26,9 +26,9 @@ func resourceFirewallRule() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				StateFunc: func(v interface{}) string {
-					switch v.(type) {
+					switch v := v.(type) {
 					case string:
-						return strings.TrimSpace(v.(string))
+						return strings.TrimSpace(v)
 					default:
 						return ""
 					}

--- a/triton/resource_key.go
+++ b/triton/resource_key.go
@@ -50,7 +50,7 @@ func resourceKeyCreate(d *schema.ResourceData, meta interface{}) error {
 		if len(parts) == 3 {
 			d.Set("name", parts[2])
 		} else {
-			return errors.New("No key name specified, and key material has no comment")
+			return errors.New("no key name specified, and key material has no comment")
 		}
 	}
 

--- a/triton/resource_key_test.go
+++ b/triton/resource_key_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TritonDataCenter/triton-go/account"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -152,7 +153,7 @@ func testCheckTritonKeyDestroy(s *terraform.State) error {
 		return err
 	}
 
-	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+	return retry.Retry(1*time.Minute, func() *retry.RetryError {
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "triton_key" {
 				continue
@@ -166,7 +167,7 @@ func testCheckTritonKeyDestroy(s *terraform.State) error {
 			}
 
 			if key != nil {
-				return resource.RetryableError(fmt.Errorf("Bad: Key %q still exists", rs.Primary.ID))
+				return retry.RetryableError(fmt.Errorf("Bad: Key %q still exists", rs.Primary.ID))
 			}
 		}
 

--- a/triton/resource_machine.go
+++ b/triton/resource_machine.go
@@ -407,11 +407,11 @@ func resourceMachineCreate(d *schema.ResourceData, meta interface{}) error {
 		volumesList := volumesRaw.(*schema.Set).List()
 		for _, v := range volumesList {
 			volumeMap, ok := v.(map[string]interface{})
-			if ok == false {
+			if !ok {
 				return fmt.Errorf("invalid volume entry")
 			}
 			volumeName, ok := volumeMap["name"].(string)
-			if ok == false {
+			if !ok {
 				return fmt.Errorf("volume entries must specify the volume name")
 			}
 			volume := compute.InstanceVolume{Name: volumeName}

--- a/triton/resource_machine.go
+++ b/triton/resource_machine.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/TritonDataCenter/triton-go/compute"
 	"github.com/TritonDataCenter/triton-go/errors"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/hashstructure"
 )
@@ -478,7 +478,7 @@ func resourceMachineCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(machine.ID)
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{machineStateRunning},
 		Refresh: func() (interface{}, string, error) {
 			inst, err := c.Instances().Get(context.Background(), &compute.GetInstanceInput{
@@ -632,7 +632,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		stateConf := &resource.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Pending: []string{oldName},
 			Target:  []string{newName},
 			Refresh: func() (interface{}, string, error) {
@@ -709,7 +709,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		stateConf := &resource.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Target: []string{strconv.FormatUint(expectedTags, 10)},
 			Refresh: func() (interface{}, string, error) {
 				inst, err := c.Instances().Get(context.Background(), &compute.GetInstanceInput{
@@ -746,7 +746,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		stateConf := &resource.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Target: []string{fmt.Sprintf("%s@%s", newPackage, "running")},
 			Refresh: func() (interface{}, string, error) {
 				inst, err := c.Instances().Get(context.Background(), &compute.GetInstanceInput{
@@ -784,7 +784,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		stateConf := &resource.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Target: []string{fmt.Sprintf("%t", enable)},
 			Refresh: func() (interface{}, string, error) {
 				inst, err := c.Instances().Get(context.Background(), &compute.GetInstanceInput{
@@ -851,7 +851,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 
-			stateConf := &resource.StateChangeConf{
+			stateConf := &retry.StateChangeConf{
 				Target: []string{"running"},
 				Refresh: func() (interface{}, string, error) {
 					n, err := c.Instances().GetNIC(context.Background(), &compute.GetNICInput{
@@ -896,7 +896,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		stateConf := &resource.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Target: []string{fmt.Sprintf("%t", deletion_protection)},
 			Refresh: func() (interface{}, string, error) {
 				inst, err := c.Instances().Get(context.Background(), &compute.GetInstanceInput{
@@ -958,7 +958,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		stateConf := &resource.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Target: []string{"converged"},
 			Refresh: func() (interface{}, string, error) {
 				inst, err := c.Instances().Get(context.Background(), &compute.GetInstanceInput{
@@ -1004,7 +1004,7 @@ func resourceMachineDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{machineStateDeleted},
 		Refresh: func() (interface{}, string, error) {
 			inst, err := c.Instances().Get(context.Background(), &compute.GetInstanceInput{

--- a/triton/resource_snapshot.go
+++ b/triton/resource_snapshot.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/TritonDataCenter/triton-go/compute"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -80,7 +80,7 @@ func resourceSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(snapshot.Name)
 
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{"created"},
 		Refresh: func() (interface{}, string, error) {
 			snapshot, err := c.Snapshots().Get(context.Background(), &compute.GetSnapshotInput{

--- a/triton/resource_volume.go
+++ b/triton/resource_volume.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/TritonDataCenter/triton-go/compute"
 	"github.com/TritonDataCenter/triton-go/errors"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -128,7 +128,7 @@ func resourceVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(volume.ID)
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{volumeStateReady},
 		Refresh: func() (interface{}, string, error) {
 			volume, err := c.Volumes().Get(context.Background(), &compute.GetVolumeInput{
@@ -231,7 +231,7 @@ func resourceVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		stateConf := &resource.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Pending: []string{oldName},
 			Target:  []string{newName},
 			Refresh: func() (interface{}, string, error) {
@@ -276,7 +276,7 @@ func resourceVolumeDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{volumeStateDeleted},
 		Refresh: func() (interface{}, string, error) {
 			inst, err := c.Volumes().Get(context.Background(), &compute.GetVolumeInput{

--- a/triton/tritonerr.go
+++ b/triton/tritonerr.go
@@ -3,7 +3,7 @@ package triton
 import (
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
 // retryOnError uses resource.Retry from Terraform core to retry a function when
@@ -12,14 +12,14 @@ import (
 // argument. Error functions can be found in `triton-go`.
 func retryOnError(isRetry func(err error) bool, f func() (interface{}, error)) (interface{}, error) {
 	var resp interface{}
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+	err := retry.Retry(2*time.Minute, func() *retry.RetryError {
 		var err error
 		resp, err = f()
 		if err != nil {
 			if isRetry(err) {
-				return resource.RetryableError(err)
+				return retry.RetryableError(err)
 			}
-			return resource.NonRetryableError(err)
+			return retry.NonRetryableError(err)
 		}
 		return nil
 	})


### PR DESCRIPTION
Follow-up to: #145 with clean-up for various `make lint` checks.

Recommendation for reviewers: check commit by commit.

Note that a few `staticcheck` exclusions have been added, because these require a code refactor to use `context.Context`.